### PR TITLE
Handle WS API userData envelope in binance_websocket()

### DIFF
--- a/unicorn_fy/unicorn_fy.py
+++ b/unicorn_fy/unicorn_fy.py
@@ -225,6 +225,14 @@ class UnicornFy(object):
             pass
 
         try:
+            if 'event' in stream_data and 'subscriptionId' in stream_data:
+                # WS API userData envelope: {"subscriptionId": 0, "event": {"e": "executionReport", ...}}
+                # Unwrap to standard format so the rest of the normalisation pipeline works unchanged.
+                stream_data = {'data': stream_data['event']}
+        except (KeyError, TypeError):
+            pass
+
+        try:
             if 'e' in stream_data and 'data' not in stream_data:
                 stream_data = {'data': stream_data}
         except TypeError:


### PR DESCRIPTION
## Summary

- Binance removed the REST listenKey endpoints for Spot/Margin in February 2026
- UBWA now connects via the WS API and receives userData events wrapped in: `{"subscriptionId": 0, "event": {"e": "executionReport", ...}}`
- `binance_websocket()` had no handler for this format → `KeyError: 'data'`

Fix: unwrap the envelope before the existing normalisation pipeline. `executionReport`, `outboundAccountPosition` and `balanceUpdate` pass through correctly without further changes — unicorn-fy already hardcodes `stream_type: '!userData@arr'` for these event types so the missing `stream` key is not an issue.

## Test plan

- [ ] `executionReport` events processed correctly
- [ ] `outboundAccountPosition` events processed correctly
- [ ] Existing unit tests pass