### PR TITLE
Fix AttributeError in get_latest_version when GitHub API request fails

### DIFF
--- a/unicorn_fy/unicorn_fy.py
+++ b/unicorn_fy/unicorn_fy.py
@@ -1268,11 +1268,12 @@ class UnicornFy(object):
 
         :return: str or False
         """
-        # Do a fresh request if status is None or last timestamp is older 1 hour
-        if self.last_update_check_github['status']['tag_name'] is None or \
+        # Do a fresh request if status is not a dict, has no tag_name, or last timestamp is older 1 hour
+        if not isinstance(self.last_update_check_github['status'], dict) or \
+                self.last_update_check_github['status'].get('tag_name') is None or \
                 (self.last_update_check_github['timestamp'] + (60 * 60) < time.time()):
             self.last_update_check_github['status'] = self.get_latest_release_info()
-        if self.last_update_check_github['status']:
+        if isinstance(self.last_update_check_github['status'], dict) and self.last_update_check_github['status']:
             try:
                 return self.last_update_check_github['status']['tag_name']
             except KeyError:


### PR DESCRIPTION
## Summary
- `get_latest_release_info()` can return `False` on failure
- `get_latest_version()` accessed `['tag_name']` directly without checking if status is a dict
- Fix: check `isinstance(status, dict)` before accessing keys

Same bug as oliver-zehentleitner/unicorn-binance-rest-api#105, oliver-zehentleitner/unicorn-binance-websocket-api#417, oliver-zehentleitner/unicorn-binance-local-depth-cache#57.