### PR TITLE
Add CHANGELOG entry for get_latest_version fix (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-fyreadme.html#installation-and-upgrade)
 
 ## 0.17.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_latest_version()`: handle `False` return from `get_latest_release_info()` gracefully instead of
+  crashing with `AttributeError` when the GitHub API request fails (#69)
 
 ## 0.17.0
 ### Fixed


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry under `0.17.0.dev` for the `get_latest_version()` fix merged in #69

## Test plan
- [ ] Verify CHANGELOG formatting is correct