### PR TITLE
Format example output in README as one key per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,18 @@ print(unicorn_fied_stream_data)
 Output:
 
 ```
-{'stream_type': 'btcusdt@trade', 'event_type': 'trade', 'event_time': 1556876873656, 'symbol': 'BTCUSDT',
- 'trade_id': 117727701, 'price': '5786.76000000', 'quantity': '0.03200500', 'buyer_order_id': 341831847,
- 'seller_order_id': 341831876, 'trade_time': 1556876873648, 'is_market_maker': True, 'ignore': True,
+{'stream_type': 'btcusdt@trade',
+ 'event_type': 'trade',
+ 'event_time': 1556876873656,
+ 'symbol': 'BTCUSDT',
+ 'trade_id': 117727701,
+ 'price': '5786.76000000',
+ 'quantity': '0.03200500',
+ 'buyer_order_id': 341831847,
+ 'seller_order_id': 341831876,
+ 'trade_time': 1556876873648,
+ 'is_market_maker': True,
+ 'ignore': True,
  'unicorn_fied': ['binance', '0.17.0']}
 ```
 


### PR DESCRIPTION
## Summary
- Reformatted the example output dict from a single long line to one key-value pair per line for better readability

## Test plan
- [ ] Verify README renders correctly on GitHub