### PR TITLE
Rewrite project description: normalization layer, not an SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [Examples](#examples) | [Wiki](#wiki) | [Social](#social) | [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) 
 | [Contributing](#contributing) | [Disclaimer](#disclaimer) 
 
-A Python SDK to convert received raw data from crypto exchange API endpoints into well-formed python dictionaries.
+Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, cleanly-typed Python dictionaries. A transformation layer that makes exchange data interchangeable instead of exchange-specific.
 
 Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -21,7 +21,7 @@
 [Examples](#examples) | [Wiki](#wiki) | [Social](#social) | [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) 
 | [Contributing](#contributing) | [Disclaimer](#disclaimer) 
 
-A Python SDK to convert received raw data from crypto exchange API endpoints into well-formed python dictionaries.
+Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, cleanly-typed Python dictionaries. A transformation layer that makes exchange data interchangeable instead of exchange-specific.
 
 Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -41,8 +41,8 @@ test:
     - pip
 
 about:
-  summary: | 
-    A Python SDK to convert received raw data from crypto exchange API endpoints into well-formed python dictionaries.
+  summary: |
+    Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, cleanly-typed Python dictionaries. A transformation layer that makes exchange data interchangeable instead of exchange-specific.
   description: |
     [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-fy.svg?label=github&color=blue)](https://github.com/oliver-zehentleitner/unicorn-fy/releases)
     [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-fy/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-fy/releases)
@@ -70,8 +70,9 @@ about:
     [Examples](#examples) | [Wiki](#wiki) | [Social](#social) | [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) 
     | [Contributing](#contributing) | [Disclaimer](#disclaimer) | [Commercial Support](#commercial-support)
     
-    A Python SDK to convert received raw data from crypto exchange API endpoints 
-    into well-formed python dictionaries.
+    Normalizes raw responses from crypto exchange APIs (Binance & co.) into
+    consistent, cleanly-typed Python dictionaries. A transformation layer that
+    makes exchange data interchangeable instead of exchange-specific.
     
     Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "unicorn-fy"
 version = "0.17.1"
-description = "A Python SDK to convert received raw data from crypto exchange API endpoints into well-formed python dictionaries."
+description = "Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, cleanly-typed Python dictionaries. A transformation layer that makes exchange data interchangeable instead of exchange-specific."
 authors = ["Oliver Zehentleitner"]
 license = "MIT"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,9 @@ setup(
      version="0.17.1",
      author="Oliver Zehentleitner",
      url="https://github.com/oliver-zehentleitner/unicorn-fy",
-     description="A Python SDK to convert received raw data from crypto exchange API endpoints into "
-                 "well-formed python dictionaries.",
+     description="Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, "
+                 "cleanly-typed Python dictionaries. A transformation layer that makes exchange data "
+                 "interchangeable instead of exchange-specific.",
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',


### PR DESCRIPTION
## Summary
Old description called unicorn-fy a \"Python SDK\" — but it isn't one. There's no API client here; the library takes raw responses from crypto exchange APIs and turns them into consistent, cleanly-typed Python dicts.

New one-liner (PyPI / Conda / GitHub):

> Normalizes raw responses from crypto exchange APIs (Binance & co.) into consistent, cleanly-typed Python dictionaries. A transformation layer that makes exchange data interchangeable instead of exchange-specific.

Updated in: \`setup.py\`, \`pyproject.toml\`, \`meta.yaml\` (summary + description body), \`README.md\`, \`dev/sphinx/source/readme.md\`.

## Test plan
- [ ] Visual review of PyPI / Anaconda / GitHub rendering on next release