### PR TITLE
Update exchange list in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -113,14 +113,16 @@ body:
       options:
         - concerns all
         - binance.com
-        - binance.com-coin_futures
-        - binance.com-futures
-        - binance.com-futures-testnet
-        - binance.com-isolated_margin
-        - binance.com-isolated_margin-testnet
+        - binance.com-testnet
         - binance.com-margin
         - binance.com-margin-testnet
-        - binance.com-testnet
+        - binance.com-isolated_margin
+        - binance.com-isolated_margin-testnet
+        - binance.com-futures
+        - binance.com-futures-testnet
+        - binance.com-coin_futures
+        - binance.com-vanilla-options
+        - binance.com-vanilla-options-testnet
         - binance.us
         - trbinance.com
     validations:


### PR DESCRIPTION
## Summary
- Add `binance.com-vanilla-options` and `binance.com-vanilla-options-testnet`
- Reorder list to match logical grouping (spot, margin, futures, options)