### PR TITLE
environment.yml: switch to conda deps on conda-forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 0.17.1.dev (development stage/unreleased/unstable)
 ### Changed
+- `environment.yml`: switched from a pip-only dependency list to native
+  conda dependencies on the `conda-forge` channel. Mixing conda and pip
+  in the same environment file bypasses the conda solver for the pip
+  deps and can cause ABI/ resolver conflicts; conda-forge best practice
+  is to install everything from `conda-forge` when using conda.
 - README: switched all conda references from the legacy `lucit` channel
   to `conda-forge`. Added conda-forge version / downloads / feedstock
   build badges. Removed the "There is no conda support until migration"

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,10 @@
 name: unicorn-fy
+
+channels:
+  - conda-forge
+
 dependencies:
-- python>=3.9,<3.15
-- pip:
+  - python>=3.9,<3.15
   - Cython
-  - requests
   - orjson
+  - requests


### PR DESCRIPTION
Previously `environment.yml` installed the three runtime deps (`Cython`, `orjson`, `requests`) via pip:

```yaml
dependencies:
- python>=3.9,<3.15
- pip:
  - Cython
  - requests
  - orjson
```

Mixing conda and pip in the same environment bypasses the conda solver for the pip deps — can cause ABI / resolver conflicts. conda-forge best practice is to install everything from `conda-forge` when using conda:

```yaml
channels:
  - conda-forge
dependencies:
  - python>=3.9,<3.15
  - Cython
  - orjson
  - requests
```

All three deps are available on conda-forge.

Also drops the implicit `defaults` channel fallback (Anaconda's default channel requires a paid license for enterprise use since 2024).

Suite-wide cleanup; same style will be applied to the other module environment.yml files.