### PR TITLE
Clean remaining LUCIT references outside the conda pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
     id: Info
     attributes:
       value: | 
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/LUCIT-Systems-and-Development/unicorn-binance-suite/wiki/Issue-Guidelines). 
+        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines).
         
         Most of these fields are not mandatory, but please provide as much information as possible.
   - type: checkboxes
@@ -25,7 +25,7 @@ body:
     attributes:
       label: Version of this library.
       description: |
-        Please control what version you are using with [this script](https://github.com/LUCIT-Systems-and-Development/unicorn-binance-suite/blob/master/tools/get_versions_of_unicorn_packages.py) and post the output:
+        Please control what version you are using with [this script](https://github.com/oliver-zehentleitner/unicorn-binance-suite/blob/master/tools/get_versions_of_unicorn_packages.py) and post the output:
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/LUCIT-Systems-and-Development/unicorn-binance-suite/wiki/Issue-Guidelines). 
+        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines).
         
         Most of these fields are not mandatory, but please provide as much information as possible.
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 0.17.1.dev (development stage/unreleased/unstable)
 ### Changed
+- README: replaced the lucit.tech "UNICORN Binance WebSocket API"
+  project link with the canonical GitHub repo URL.
+- `examples/README.md`: removed the lucit.tech chat support link.
+- `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml`: updated
+  the Issue-Guidelines and version-check-script URLs from the old
+  `LUCIT-Systems-and-Development` GitHub org to `oliver-zehentleitner`.
+- `SECURITY.md`: replaced the lucit.tech contact form URL with the
+  GitHub Security Advisories private-reporting URL.
+### Changed
 - README: reworded the PyPy paragraph. The old sentence ("For the PyPy
   interpreter we offer packages only from Python version 3.9 and
   higher") made sense when we still shipped wheels for pre-3.9 CPython;

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Output:
 ```
 
 This lib is integrated into 
-[UNICORN Binance WebSocket API](https://www.lucit.tech/unicorn-binance-websocket-api.html) 
+[UNICORN Binance WebSocket API](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) 
 and can be activated by setting parameter 
 [`output_default` of `BinanceWebSocketApiManager()` to `UnicornFy`](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/unicorn_binance_websocket_api.html?highlight=output_default#module-unicorn_binance_websocket_api.manager) 
 or for specific streams with the parameter 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,12 @@ This document outlines security procedures and general policies for the `unicorn
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
-`LUCIT Systems and Development` takes all security bugs in `unicorn-fy` seriously.
+`Oliver Zehentleitner` takes all security bugs in `unicorn-fy` seriously.
 Thank you for improving the security of `unicorn-fy`. We appreciate your efforts and 
 responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs via our contact form:
-https://www.lucit.tech/contact-unicorn-developers.html
+Please report security bugs privately via GitHub Security Advisories:
+https://github.com/oliver-zehentleitner/unicorn-fy/security/advisories/new
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,9 +3,8 @@ Here you will find best practice examples for the use of UnicornFy.
 
 For each example you will find a `README.md` and a `requirements.txt` to install any dependencies. The respective `*.py` 
 file is to download and start, if an example does not work, we are happy about a 
-[patch](https://github.com/oliver-zehentleitner/unicorn-fy/fork) or a message via 
-[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-fy/issues/new/choose) or 
-[our chat](https://www.lucit.tech/get-support.html).
+[patch](https://github.com/oliver-zehentleitner/unicorn-fy/fork) or a message via
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-fy/issues/new/choose).
 
 Old examples are stored in the 
 [archive](https://github.com/oliver-zehentleitner/unicorn-fy/tree/master/examples/_archive).


### PR DESCRIPTION
### README
- Replaced the lucit.tech 'UNICORN Binance WebSocket API' integration link with the canonical GitHub repo URL.

### Issue templates
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml`: updated Issue-Guidelines URL and version-check-script URL from the old `LUCIT-Systems-and-Development` GitHub org to `oliver-zehentleitner`.

### Examples
- `examples/README.md`: removed the 'our chat' lucit.tech support link.

### Security policy
- `SECURITY.md`: replaced the lucit.tech contact form URL with the GitHub Security Advisories private-reporting URL.

Sphinx sources and the historical CHANGELOG are intentionally untouched.