### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ or the [current master branch](https://github.com/oliver-zehentleitner/unicorn-f
 - [Look here!](https://github.com/oliver-zehentleitner/unicorn-fy/tree/master/examples/)
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [UBS article series overview](https://blog.technopathy.club/series/unicorn-binance-suite)
 

--- a/llms.txt
+++ b/llms.txt
@@ -67,6 +67,10 @@ ubwa.create_stream(channels="trade", markets="btcusdt",
 
 - [UBWA](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) — the primary consumer of UnicornFy; set `output_default="UnicornFy"` to skip manual normalization calls.
 
+## Related Articles
+
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; positions UnicornFy within the UNICORN Binance Suite landscape (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) and helps users pick the right module.
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-fy


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → new `## Related Articles` section (didn't exist yet) with an LLM-oriented description

## Test plan

- [ ] Render README on GitHub and verify link position
- [ ] Open the link, confirm it resolves