### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this library.
 > **This file** is for AI agents working *on* this repo itself.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
@@ -56,7 +60,7 @@ dev/sphinx/                # Sphinx source for rebuilding docs
 
 Managed in `requirements.txt`, `setup.py`, and `pyproject.toml` — **all three must be kept in sync manually**:
 
-- `orjson` — fast JSON serialization (suite-wide standard)
+- `orjson` — fast JSON serialization (suite-wide standard, replaced `ujson` — see [`context/history.md`](context/history.md))
 - `requests` — HTTP for version checks
 - `Cython` — C extension compilation (release builds only)
 
@@ -97,7 +101,8 @@ python setup.py bdist_wheel
 - `unit-tests.yml` — Python 3.9–3.14 on Ubuntu, Codecov upload
 - `build_wheels.yml` — Manual trigger, builds wheels for Linux/macOS/Windows, PyPI release
 - `codeql-analysis.yml` — Security scanning
-- `build_conda.yml` — Conda package build
+
+No in-repo conda build — conda-forge's own feedstock is the only conda source (see [`context/history.md`](context/history.md)).
 
 ---
 
@@ -117,6 +122,8 @@ python setup.py bdist_wheel
 | Class | File | Purpose |
 |---|---|---|
 | `UnicornFy` | `unicorn_fy/unicorn_fy.py` | All conversion logic; static methods per exchange |
+
+Why unrecognized event shapes are tolerated rather than raised, and how the WS API userData envelope is handled: [`context/adapters.md`](context/adapters.md).
 
 ---
 
@@ -141,3 +148,8 @@ result = ufy.binance_com_websocket(raw_json_string)
 UnicornFy is used automatically by `unicorn-binance-websocket-api` when:
 - `output_default="UnicornFy"` is set on `BinanceWebSocketApiManager()`
 - `output="UnicornFy"` is set on individual `create_stream()` calls
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-fy)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.

--- a/context/adapters.md
+++ b/context/adapters.md
@@ -1,0 +1,28 @@
+# Adapting to Binance's stream shape changes
+
+## WS API userData envelope unwrap
+
+**Status:** active
+**Confirmed** (commit `1503d59`, merge `3b2e144`, 2026-04-10)
+
+Binance removed the REST listenKey endpoints for Spot/Margin in February 2026. UBWA switched to the WS API subscription flow instead, which wraps userData events in `{"subscriptionId": 0, "event": {...}}`. `binance_websocket()` now unwraps that envelope before handing the payload to the existing normalization pipeline.
+
+**Reason:** this is a forced adaptation to an external Binance API change, not a design choice — the envelope shape is Binance's, not this library's.
+
+## Catch-all replacing an event-type whitelist
+
+**Status:** active
+**Confirmed** (commit `31d7fa1`, fixes #41)
+
+Previously, only explicitly-listed event types were unwrapped/normalized; anything else fell through and crashed with `KeyError: 'data'`. Replaced with a catch-all: any payload with a top-level `e` key and no `data` wrapper (e.g. `listenKeyExpired`) is now wrapped, instead of relying on an enumerated list of known event types.
+
+**Rejected alternative:** keep extending the explicit whitelist every time Binance adds a new event type.
+
+**Reason:** the whitelist approach means the library breaks on every new Binance event type until someone notices and adds it — the catch-all tolerates unknown-but-well-shaped events instead of crashing on them. This explains the number of bare `except KeyError: pass` blocks throughout `unicorn_fy.py` — see `open-questions.md` for how this pattern sits against the suite's fail-loud convention.
+
+## Init value `False` → `{}`
+
+**Status:** active
+**Confirmed** (commit `f8d6341`, fixes #44)
+
+`unicorn_fied_data` was initialized to `False`; an unmatched event type left it as `False`, and the next step (item assignment) crashed with `TypeError: bool object does not support item assignment`. Changed the default to `{}`.

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,21 @@
+# History
+
+## Three-org lineage
+
+**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Confirmed** (git history)
+
+The repo's earliest commits (from 2019-04, e.g. `562af8e`) reference `github.com/unicorn-data-analysis/unicorn-binance-websocket-api` and an `@unicorn-data.com` author email — a pre-LUCIT identity, not a LUCIT-first origin like the framing used elsewhere might suggest. It moved to the `LUCIT-Systems-and-Development` org in 2022 (commits `e5b82fc`, `b207c7a`, both 2022-01-03), briefly switched to a proprietary `LSOSL` license in 2023-11 (commit `1c78b1f`) — reverted back to MIT roughly 2.5 weeks later (`2310d9b`/`9ee5aae`) — and finally de-branded to `oliver-zehentleitner` in 2025-06. Residual cleanup (conda-forge migration, `build_conda.yml` removal, remaining org-URL references) continued into April 2026 (`11ef2c3`, `4212c7c`).
+
+**Reason:** LUCIT is no longer part of how this project is licensed, distributed, or supported. The LSOSL license switch itself appears to have been a short-lived experiment reverted quickly, not a lasting decision.
+
+**Confirmed: this repo was split out of `unicorn-binance-websocket-api`.** This repo's own initial commit (`562af8e`, 2019-04-04) is a fresh, empty repo (just `LICENSE`/`README.md`/`.gitignore`) — but its next few commits (e.g. `ea33d69`) already reference issue URLs under `github.com/unicorn-data-analysis/unicorn-binance-websocket-api`, i.e. the combined project this code originally lived in. The split itself is documented in the *other* repo's history: `unicorn-binance-websocket-api` commit `04868179` (2019-04-30): "unicorn_fy bug, splitting unicorn_fy and websocket into 2 projects." So the normalization logic and the WebSocket client were one project for the first few weeks, then split into today's two repos.
+
+## `orjson` as the suite-wide JSON standard
+
+**Status:** active
+**Confirmed** (commit `637911a`)
+
+`orjson` replaced `ujson` here, framed explicitly as a suite-wide standardization, not a per-repo preference. The same commit also fixed an unrelated bug: `binance_websocket()` had `unicorn_fied` containing a method reference instead of the actual version string.
+
+**Reason:** consistency across the suite's modules (see the parallel `ujson`→stdlib/`orjson` cleanups in the sibling REST-API and WebSocket-API repos) rather than a reason specific to this repo.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,5 @@
+# Context index
+
+- [adapters.md](adapters.md) — why the userData envelope gets unwrapped, and the shift from an event-type whitelist to a catch-all
+- [history.md](history.md) — the three-org lineage (unicorn-data-analysis → LUCIT → oliver-zehentleitner), and the suite-wide switch to `orjson`
+- [open-questions.md](open-questions.md) — the bare `except KeyError: pass` pattern, and how it sits against the suite's fail-loud convention

--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -1,0 +1,9 @@
+# Open questions
+
+## Bare `except KeyError: pass` blocks vs. the suite's fail-loud convention
+
+**Status:** unknown — needs maintainer input
+
+`unicorn_fy.py` has dozens of bare `except KeyError: pass` blocks (e.g. around lines 214, 224, 252, 259, 273...) that silently tolerate schema mismatches rather than raising. Commit `31d7fa1` (see `adapters.md`) shows this is a deliberate pattern for tolerating varying/unknown event shapes from Binance, not an oversight.
+
+**Why this needs an answer:** the rest of the suite documents a "fail loud on broken invariants, never silently continue" convention (see the sibling `unicorn-binance-depth-cache-cluster`'s `context/fail-loud.md` for a concrete example). Whether this repo's catch-all-and-swallow pattern is considered a deliberate, scoped exception to that convention (tolerating *shape* variance in an adapter layer, as opposed to *data-integrity* violations like an out-of-sync order book) or something worth tightening isn't stated anywhere. Worth asking directly rather than assuming either way.


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: context/adapters.md (why unrecognized event shapes are tolerated rather than raised, the WS API userData envelope unwrap), context/history.md (the three-org lineage incl. confirming the 2019 split from unicorn-binance-websocket-api, the orjson standardization), context/open-questions.md (how the bare except-KeyError-pass pattern sits against the suite's fail-loud convention)
- AGENTS.md trimmed to pointers; fixed a stale claim (build_conda.yml no longer exists)
- README.md: Keep the Why badge
- .gitignore: AGENTS.local.md (not committed)

## Test plan
- [ ] Read through context/*.md for accuracy against actual history
- [ ] Weigh in on the open question (except-KeyError-pass vs. fail-loud)