### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,4 +152,6 @@ UnicornFy is used automatically by `unicorn-binance-websocket-api` when:
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/adapters.md
+++ b/context/adapters.md
@@ -3,7 +3,8 @@
 ## WS API userData envelope unwrap
 
 **Status:** active
-**Confirmed** (commit `1503d59`, merge `3b2e144`, 2026-04-10)
+**Evidence:** confirmed
+**Source:** commit `1503d59`, merge `3b2e144`, 2026-04-10
 
 Binance removed the REST listenKey endpoints for Spot/Margin in February 2026. UBWA switched to the WS API subscription flow instead, which wraps userData events in `{"subscriptionId": 0, "event": {...}}`. `binance_websocket()` now unwraps that envelope before handing the payload to the existing normalization pipeline.
 
@@ -12,7 +13,8 @@ Binance removed the REST listenKey endpoints for Spot/Margin in February 2026. U
 ## Catch-all replacing an event-type whitelist
 
 **Status:** active
-**Confirmed** (commit `31d7fa1`, fixes #41)
+**Evidence:** confirmed
+**Source:** commit `31d7fa1`, fixes #41
 
 Previously, only explicitly-listed event types were unwrapped/normalized; anything else fell through and crashed with `KeyError: 'data'`. Replaced with a catch-all: any payload with a top-level `e` key and no `data` wrapper (e.g. `listenKeyExpired`) is now wrapped, instead of relying on an enumerated list of known event types.
 
@@ -23,6 +25,7 @@ Previously, only explicitly-listed event types were unwrapped/normalized; anythi
 ## Init value `False` → `{}`
 
 **Status:** active
-**Confirmed** (commit `f8d6341`, fixes #44)
+**Evidence:** confirmed
+**Source:** commit `f8d6341`, fixes #44
 
 `unicorn_fied_data` was initialized to `False`; an unmatched event type left it as `False`, and the next step (item assignment) crashed with `TypeError: bool object does not support item assignment`. Changed the default to `{}`.

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## Three-org lineage
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
-**Confirmed** (git history)
+**Evidence:** confirmed
+**Source:** git history
 
 The repo's earliest commits (from 2019-04, e.g. `562af8e`) reference `github.com/unicorn-data-analysis/unicorn-binance-websocket-api` and an `@unicorn-data.com` author email — a pre-LUCIT identity, not a LUCIT-first origin like the framing used elsewhere might suggest. It moved to the `LUCIT-Systems-and-Development` org in 2022 (commits `e5b82fc`, `b207c7a`, both 2022-01-03), briefly switched to a proprietary `LSOSL` license in 2023-11 (commit `1c78b1f`) — reverted back to MIT roughly 2.5 weeks later (`2310d9b`/`9ee5aae`) — and finally de-branded to `oliver-zehentleitner` in 2025-06. Residual cleanup (conda-forge migration, `build_conda.yml` removal, remaining org-URL references) continued into April 2026 (`11ef2c3`, `4212c7c`).
 
@@ -14,7 +15,8 @@ The repo's earliest commits (from 2019-04, e.g. `562af8e`) reference `github.com
 ## `orjson` as the suite-wide JSON standard
 
 **Status:** active
-**Confirmed** (commit `637911a`)
+**Evidence:** confirmed
+**Source:** commit `637911a`
 
 `orjson` replaced `ujson` here, framed explicitly as a suite-wide standardization, not a per-repo preference. The same commit also fixed an unrelated bug: `binance_websocket()` had `unicorn_fied` containing a method reference instead of the actual version string.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.