### PR TITLE
ci: enforce black formatting on push/PR

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
 
     - name: Install black
       run: pip install black==26.5.1

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,25 @@
+name: Black
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+
+    - name: Install black
+      run: pip install black==26.5.1
+
+    - name: Check formatting
+      run: black --check --diff .


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/black.yml`: runs `black --check --diff .` on every push/PR to `master`, pinned to `black==26.5.1` (the version used for the formatting pass in #92/#93)
- Follow-up to the black rollout — makes formatting mandatory going forward instead of just a one-time pass